### PR TITLE
Fix env, NotFound page, tests, ESLint config

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,7 @@
 # REPLACE THE VALUES BELOW WITH YOUR ACTUAL KEYS IF NOT AUTOMATICALLY SET
 
 VITE_SUPABASE_URL=https://dummy.supabase.co
-VITE_SUPABASE_ANON_KEY=dummykey.updateyourkkey.here
+VITE_SUPABASE_ANON_KEY=dummykey.updateyourkey.here
 VITE_OPENAI_API_KEY=your-openai-api-key-here
 VITE_GEMINI_API_KEY=your-gemini-api-key-here
 VITE_ANTHROPIC_API_KEY=your-anthropic-api-key-here

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,16 @@
+module.exports = {
+  env: { browser: true, es2021: true, node: true },
+  extends: [
+    'eslint:recommended',
+    'plugin:react/recommended'
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  settings: {
+    react: { version: 'detect' }
+  },
+  plugins: ['react'],
+  rules: {}
+};

--- a/package.json
+++ b/package.json
@@ -60,13 +60,8 @@
     "build": "vite build --sourcemap",
     "serve": "vite preview",
     "lint": "eslint src --ext js,jsx --report-unused-disable-directives --max-warnings 0",
-    "preview": "vite preview"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "browserslist": {
     "production": [
@@ -97,6 +92,8 @@
     "tailwindcss-elevation": "^2.0.0",
     "tailwindcss-fluid-type": "^2.0.7",
     "vite": "5.0.0",
-    "vite-tsconfig-paths": "3.6.0"
+    "vite-tsconfig-paths": "3.6.0",
+    "vitest": "^1.3.0",
+    "jsdom": "^24.0.0"
   }
 }

--- a/src/components/ui/__tests__/Button.test.jsx
+++ b/src/components/ui/__tests__/Button.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Button from '../Button';
+import matchers from '@testing-library/jest-dom/matchers';
+
+expect.extend(matchers);
+
+describe('Button component', () => {
+  it('renders icon when iconName is provided', () => {
+    const { container } = render(<Button iconName="ArrowLeft">Back</Button>);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('applies outline variant classes', () => {
+    const { getByRole } = render(<Button variant="outline">Outline</Button>);
+    const button = getByRole('button', { name: /outline/i });
+    expect(button.className).toMatch(/border-2/);
+  });
+});

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import Button from 'components/ui/Button';
-import Icon from 'components/AppIcon';
 
 const NotFound = () => {
   const navigate = useNavigate();
@@ -19,15 +18,15 @@ const NotFound = () => {
           </div>
         </div>
 
-        <h2 className="text-2xl font-medium text-onBackground mb-2">Page Not Found</h2>
-        <p className="text-onBackground/70 mb-8">
+        <h2 className="text-2xl font-medium text-text-primary mb-2">Page Not Found</h2>
+        <p className="text-text-secondary mb-8">
           The page you're looking for doesn't exist. Let's get you back!
         </p>
 
         <div className="flex flex-col sm:flex-row gap-4 justify-center">
           <Button
             variant="primary"
-            icon={<Icon name="ArrowLeft" />}
+            iconName="ArrowLeft"
             iconPosition="left"
             onClick={() => window.history.back()}
           >
@@ -36,7 +35,7 @@ const NotFound = () => {
 
           <Button
             variant="outline"
-            icon={<Icon name="Home" />}
+            iconName="Home"
             iconPosition="left"
             onClick={handleGoHome}
           >

--- a/src/pages/analytics-performance-dashboard/index.jsx
+++ b/src/pages/analytics-performance-dashboard/index.jsx
@@ -114,7 +114,6 @@ const AnalyticsPerformanceDashboard = () => {
 
   return (
     <div className="mobile-full-height mobile-viewport-fix bg-background">
-      {/* Remove Header component - CRITICAL FIX */}
       <div className="hidden lg:block">
         <QuickActionToolbar />
       </div>

--- a/src/pages/link-content-management/index.jsx
+++ b/src/pages/link-content-management/index.jsx
@@ -338,7 +338,6 @@ const LinkContentManagement = () => {
 
   return (
     <div className="mobile-full-height mobile-viewport-fix bg-background">
-      {/* Remove Header component - CRITICAL FIX */}
       <div className="hidden lg:block">
         <QuickActionToolbar />
       </div>

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths(), react()],
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- correct Supabase placeholder in `.env`
- adjust NotFound button props and styles
- remove outdated header-removal comments
- configure Vitest via `vite.config.mjs`
- add basic Button component test
- add ESLint config and script for `vitest`

## Testing
- `npm test --silent --run`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_b_688383bef5b0832a8d73368df1d3c41d